### PR TITLE
Fixed "requires key not supported" warning in Minecraft log.

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
   "mixins": [
   	"nbttooltip.client.json"
   ],
-  "requires": {
+  "depends": {
     "fabricloader": ">=0.4.0",
     "fabric": "*"
   },


### PR DESCRIPTION
Swaps requires tag in fabric.mod.json with depends, which is more kosher in the Fabric system. Also removes a warning in the log every time Minecraft starts.