### PR TITLE
Update to 1.18.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.10-SNAPSHOT'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 version = "${mod_version}-fabric"
 archivesBaseName = "nbttooltip"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.17
-yarn_mappings=1.17+build.10
-loader_version=0.11.5
+minecraft_version=1.18.1
+yarn_mappings=1.18.1+build.2
+loader_version=0.12.11
 
-fabric_version=0.35.1+1.17
-modmenu_version=2.0.2
-clothconfig_version=5.0.34
-rei_version=6.0.249-alpha
+fabric_version=0.44.0+1.18
+modmenu_version=3.0.0
+clothconfig_version=6.1.48
+rei_version=7.0.352
 
 mod_version = 1.4.0
 maven_group = zabi.minecraft.nbttooltip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip

--- a/src/main/java/zabi/minecraft/nbttooltip/NBTTooltip.java
+++ b/src/main/java/zabi/minecraft/nbttooltip/NBTTooltip.java
@@ -130,12 +130,11 @@ public class NBTTooltip implements ClientModInitializer {
 			for (int i = 0; i < lines; i++) {
 				newttip.add(ttip.get(i+line_scrolled));
 			}
-			return newttip;
 		} else {
 			line_scrolled = 0;
 			newttip.addAll(ttip);
-			return newttip;
 		}
+		return newttip;
 	}
 
 	public static void onInjectTooltip(ItemStack stack, TooltipContext context, List<Text> list) {
@@ -149,7 +148,7 @@ public class NBTTooltip implements ClientModInitializer {
 			} else {
 				list.add(new LiteralText(""));
 			}
-			NbtCompound tag = stack.getTag();
+			NbtCompound tag = stack.getNbt();
 			ArrayList<Text> ttip = new ArrayList<>(lines);
 			if (tag!=null) {
 				if (ModConfig.INSTANCE.showDelimiters) {
@@ -189,7 +188,7 @@ public class NBTTooltip implements ClientModInitializer {
 		StringBuilder sb = new StringBuilder();
 		String name = I18n.translate(stack.getTranslationKey());
 		ArrayList<Text> nbtData = new ArrayList<>();
-		getCopyingEngine().parseTagToList(nbtData, stack.getTag(), false);
+		getCopyingEngine().parseTagToList(nbtData, stack.getNbt(), false);
 		nbtData.forEach(t -> {
 			sb.append(t.asString().replaceAll("§[0-9a-gk-or]", ""));
 			sb.append("\n");

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,6 @@
     "fabricloader": ">=0.12.11",
     "fabric": "*",
     "minecraft": "1.18.1",
-    "java": ">=16"
+    "java": ">=17"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,9 +21,9 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.11.3",
+    "fabricloader": ">=0.12.11",
     "fabric": "*",
-    "minecraft": "1.17.x",
+    "minecraft": "1.18.1",
     "java": ">=16"
   }
 }


### PR DESCRIPTION
Not much changed. Just updated dependency versions and gradle versions for 1.18.1 and Java 17 support.

Removed common parts from NBTTooltip#transformTtip ifelse statement, and updated ItemStack Nbt getter.

Works in both dev and client environments.